### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,11 @@
+[run]
+source = zope.minmax
+
 [report]
+precision = 2
 exclude_lines =
-    # pragma: no cover
-    class I[A-Z]\w+\((Interface|I[A-Z].*)\):
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,20 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
+    - 3.6
     - pypy
-    - pypy3
+    - pypy3.5-5.8.0
 install:
-    - pip install .
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test,docs]
 script:
-    - python setup.py -q test -q
+    - coverage run -m zope.testrunner --test-path=src
+    - coverage run -a -m sphinx -b doctest -d docs/_build/doctrees docs docs/_build/doctest
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,21 +1,23 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 2.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 - Bring unit test coverage to 100% (including branches).
 
 - Convert doctests to Sphinx documentation, including building docs
   and running doctest snippets under ``tox``.
 
+- Host documentation at https://zopeminmax.readthedocs.io
 
 2.1.0 (2014-12-27)
-------------------
+==================
 
 - Add support for PyPy3.
 
@@ -23,7 +25,7 @@ Changes
 
 
 2.0.0 (2013-02-19)
-------------------
+==================
 
 - Add support for Python 3.3 and PyPy.
 
@@ -34,37 +36,37 @@ Changes
 
 
 1.1.2 (2009-09-24)
-------------------
+==================
 
 - Use the standard Python doctest module instead of the deprecated
   zope.testing.doctest.
 
 
 1.1.1 (2009-09-09)
-------------------
+==================
 
 - Fix homepage link and mailing list address.
 
 
 1.1 (2007-10-02)
-----------------
+================
 
 - Refactor package setup.
 
 
 1.0 (2007-09-28)
-----------------
+================
 
 - No further changes since 1.0b2
 
 
 1.0b2 (2007-07-09)
-------------------
+==================
 
 - Remove ``_p_independent`` method from ``AbstractValue`` class.
 
 
 1.0b1 (2007-07-03)
-------------------
+==================
 
 - Initial release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,13 @@ include *.txt
 include bootstrap.py
 include buildout.cfg
 include tox.ini
+include .coveragerc
+include .travis.yml
 
 recursive-include src *
+recursive-include docs *.bat
+recursive-include docs *.py
+recursive-include docs *.rst
+recursive-include docs Makefile
 
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,18 +1,26 @@
-``zope.minmax``
-===============
+=================
+ ``zope.minmax``
+=================
 
 .. image:: https://img.shields.io/pypi/v/zope.minmax.svg
-    :target: https://pypi.python.org/pypi/zope.minmax/
-    :alt: Latest Version
+        :target: https://pypi.python.org/pypi/zope.minmax/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.minmax.svg
+        :target: https://pypi.org/project/zope.minmax/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.minmax.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.minmax
 
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.minmax/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.minmax?branch=master
+
 .. image:: https://readthedocs.org/projects/zopeminmax/badge/?version=latest
-        :target: http://zopeminmax.readthedocs.io/en/latest/
+        :target: https://zopeminmax.readthedocs.io/en/latest/
         :alt: Documentation Status
 
 This package provides support for homogeneous values favoring maximum
-or minimum for ZODB conflict resolution.
+or minimum (e.g., numbers) for ZODB conflict resolution.
 
-See http://zopeminmax.readthedocs.io for a detailed description.
+See https://zopeminmax.readthedocs.io for a detailed description.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,6 @@ cover-branches=1
 cover-min-percentage=100
 with-doctest=0
 where=src
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,12 @@ setup(
     description=(
         "Homogeneous values favoring maximum or minimum for ZODB "
         "conflict resolution"
-        ),
+    ),
     long_description=(
         read('README.rst')
         + '\n\n' +
         read('CHANGES.rst')
-        ),
+    ),
     license='ZPL 2.1',
     keywords=('zope3 zope zodb minimum maximum conflict resolution'),
     classifiers=[
@@ -53,27 +53,33 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        ],
-    url='http://pypi.python.org/pypi/zope.minmax/',
+    ],
+    url='https://zopeminmax.readthedocs.io',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope',],
-    extras_require=dict(
-        test=[],    # removed zope.testing; leaving for backward compatibility
-        ),
+    extras_require={
+        'test': [
+            'zope.testrunner',
+        ],
+        'docs': [
+            'Sphinx',
+            'repoze.sphinx.autointerface',
+        ],
+    },
     install_requires=[
         'persistent',
         'setuptools',
         'zope.interface',
-        ],
-    test_suite = 'zope.minmax.tests.test_suite',
+    ],
+    test_suite='zope.minmax.tests.test_suite',
     include_package_data=True,
     zip_safe=False,
-    )
+)

--- a/src/zope/minmax/tests.py
+++ b/src/zope/minmax/tests.py
@@ -2,6 +2,12 @@ import unittest
 
 class ConformsToIAbstractValue(object):
 
+    def _getTargetClass(self):
+        raise NotImplementedError()
+
+    def _makeOne(self, *args, **kw):
+        raise NotImplementedError()
+
     def test_class_conforms_to_IAbstractValue(self):
         from zope.interface.verify import verifyClass
         from zope.minmax.interfaces import IAbstractValue
@@ -100,6 +106,4 @@ class MinimumTests(unittest.TestCase, ConformsToIAbstractValue):
 
 
 def test_suite():
-    return unittest.TestSuite((
-        unittest.makeSuite(AbstractValueTests),
-    ))
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,32 +1,25 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3,coverage,docs
+    py27,py34,py35,py36,pypy,pypy3,coverage,docs
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
-# (and it seems I can't use zope.dottedname[testing] here, so forget DRY)
+    zope-testrunner --test-path=src []
+    sphinx-build -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
 deps =
-    persistent
-    zope.interface
+    .[test,docs]
 
 [testenv:coverage]
+usedevelop = true
 basepython =
     python2.7
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y zope.minmax
-    pip install -e .
-    nosetests --with-xunit --with-xcoverage
+    coverage run -m zope.testrunner --test-path=src
+    coverage run -a -m sphinx -b doctest -d {envdir}/.cache/doctrees docs {envdir}/.cache/doctest
+    coverage report --fail-under=100
 deps =
-    nose
+    {[testenv]deps}
     coverage
-    nosexcover
-    persistent
-    zope.interface
 
 [testenv:docs]
 basepython =
@@ -34,7 +27,3 @@ basepython =
 commands =
     sphinx-build -b html -d docs/_build/doctrees docs docs/_build/html
     sphinx-build -b doctest -d docs/_build/doctrees docs docs/_build/doctest
-deps =
-    {[testenv]deps}
-    Sphinx
-    repoze.sphinx.autointerface


### PR DESCRIPTION
- Badges
- Enable coveralls and ensure we hit 100%
  - We weren't running most of the tests!
- Switch to zope.testrunner
- Run doctests on all versions of Python and on CI.
- Universal wheel.