### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-3.1 (unreleased)
+4.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 3.0 (2025-08-11)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def read(*rnames):
 
 setup(
     name='zope.minmax',
-    version='3.1.dev0',
+    version='4.0.dev0',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.dev',
     description=(

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -66,13 +65,10 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     url='https://zopeminmax.readthedocs.io',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['zope'],
     python_requires='>=3.9',
     extras_require={
         'test': [
-            'zope.testrunner',
+            'zope.testrunner >= 6.4',
         ],
         'docs': [
             'Sphinx',

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
